### PR TITLE
Use public resolvers, fix mocks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -eu
 TODAY=$(date +%Y%m%d)
 
 REGISTRY=ghcr.io
-IMAGE_BASE=nijave/webhook-dyn-dnsimple
+IMAGE_BASE=nijave/webhook-txt-dnsimple
 
 docker build \
 	-t $REGISTRY/$IMAGE_BASE \


### PR DESCRIPTION
- Use public resolvers to avoid issues with split horizon DNS
- Fix mocks and add assertion to make sure the resolve command is returning an actual answer